### PR TITLE
CC-26572 Extension point for replacement strategies

### DIFF
--- a/src/Spryker/Client/CartExtension/Dependency/Plugin/QuoteStorageStrategyPluginInterface.php
+++ b/src/Spryker/Client/CartExtension/Dependency/Plugin/QuoteStorageStrategyPluginInterface.php
@@ -152,10 +152,11 @@ interface QuoteStorageStrategyPluginInterface
     /**
      * Specification:
      *  - Reloads all items in cart as new, it recreates all items transfer, reads new prices, options, bundles.
+     *  - From next major version (Forward Compatibility): Returns `QuoteResponseTransfer`.
      *
      * @api
      *
-     * @return void
+     * @return \Generated\Shared\Transfer\QuoteResponseTransfer
      */
     public function reloadItems();
 


### PR DESCRIPTION
Branch: backport/1.12.0
Ticket: https://spryker.atlassian.net/browse/CC-26572
Target Version: 1.12.0
RG: https://release.spryker.com/release-groups/view/4923

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   CartExtension               | minor                 |                      |

#### Release Notes

{skip}

-----------------------------------------

#### Module CartExtension

##### Change log

Improvements

- Adjusted `QuoteStorageStrategyPluginInterface::reloadItems()` so it returns `QuoteResponse` transfer object instead of `void`.